### PR TITLE
Implement webrtc p2p audio streaming

### DIFF
--- a/webrtc-p2p/README.md
+++ b/webrtc-p2p/README.md
@@ -1,0 +1,46 @@
+# WebRTC P2P Audio (Manual Signaling)
+
+A single-page app to stream microphone audio peer-to-peer between two devices using WebRTC, without any backend. Signaling is done via copy/paste codes.
+
+## How it works
+
+- The page uses STUN servers only for NAT traversal. There is no TURN relay.
+- One device creates an Offer Code and sends it to the other device through any channel (IM, QR, etc.).
+- The other device creates an Answer Code and sends it back.
+- Each code contains the SDP offer/answer with ICE candidates embedded (non-trickle), so no continuous signaling is required.
+
+## Quick start (local test on one device)
+
+1. Serve the folder locally (e.g., `python3 -m http.server 8000` from this directory).
+2. Open `http://localhost:8000/webrtc-p2p/` in your browser.
+3. In the left panel, click "Start mic and create Offer Code" and allow mic.
+4. Copy the Offer Code.
+5. In the right panel, paste the Offer Code, click "Create Answer Code" and allow mic.
+6. Copy the Answer Code.
+7. Paste the Answer Code back into the left panel and click "Apply Answer Code and Connect".
+
+You should see the connection state change to Connected and hear remote audio (loopback between tabs works for testing, though echo cancellation can interfere).
+
+## Using across two devices (no server signaling)
+
+- Open the same page on both devices (you can host locally and access via LAN). Due to browser security, microphone access typically requires HTTPS except on `localhost`. If you access the page via `http://<LAN-IP>:8000`, some browsers (e.g., Chrome on Android/iOS Safari) will block mic access.
+- Options:
+  - Use HTTPS locally (e.g., via Caddy, mkcert, or another HTTPS static server).
+  - Alternatively, run the static server on each device and access via `localhost` on each device, then exchange codes through any channel.
+
+## Limitations
+
+- No TURN server: in restrictive NAT environments, peers may fail to connect.
+- Manual signaling: you must copy/paste the codes yourself.
+- Audio only.
+
+## Troubleshooting
+
+- If you see "Microphone permission denied": ensure the origin is secure (HTTPS or localhost) and that your browser has mic permission.
+- If connection gets stuck at `checking` or `failed`: your networks may not allow direct connectivity without TURN.
+- If no audio: check system volume, OS input/output devices, and that the `Remote Audio` element is not muted.
+
+## Privacy
+
+- No data is sent to any backend by this page.
+- Audio is end-to-end between the two browsers once connected.

--- a/webrtc-p2p/index.html
+++ b/webrtc-p2p/index.html
@@ -1,0 +1,297 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WebRTC P2P Audio (Manual Signaling)</title>
+  <style>
+    html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
+    .container { max-width: 960px; margin: 0 auto; padding: 16px; }
+    h1 { font-size: 20px; margin: 0 0 8px; }
+    h2 { font-size: 16px; margin: 24px 0 8px; }
+    .cols { display: grid; grid-template-columns: 1fr; gap: 16px; }
+    @media (min-width: 860px) { .cols { grid-template-columns: 1fr 1fr; } }
+    .panel { border: 1px solid #ddd; border-radius: 8px; padding: 12px; }
+    textarea { width: 100%; min-height: 120px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 12px; }
+    button { padding: 8px 12px; margin: 6px 6px 6px 0; cursor: pointer; }
+    .row { margin: 8px 0; }
+    .muted { color: #666; }
+    .status { padding: 8px 12px; background: #f7f7f7; border: 1px solid #eee; border-radius: 6px; font-size: 13px; }
+    .audio { margin-top: 16px; }
+    .small { font-size: 12px; }
+    .ok { color: #0a7c2f; }
+    .warn { color: #a15b00; }
+    .err { color: #a10000; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>WebRTC P2P Audio (Manual Signaling)</h1>
+    <div class="status" id="status">Idle</div>
+
+    <div class="cols">
+      <div class="panel">
+        <h2>Step A (Caller): Create Offer</h2>
+        <div class="row small muted">This side starts the connection. It will ask for microphone permission.</div>
+        <div class="row">
+          <button id="btnOffer">Start mic and create Offer Code</button>
+          <button id="btnCopyOffer" disabled>Copy Offer Code</button>
+        </div>
+        <textarea id="offerOut" placeholder="Your Offer Code will appear here" readonly></textarea>
+        <div class="row small muted">Send this Offer Code to the other device using any channel (chat, QR, etc.).</div>
+
+        <h2>Step C (Caller): Apply Answer</h2>
+        <div class="row small muted">Paste the Answer Code received from the other device, then connect.</div>
+        <textarea id="answerIn" placeholder="Paste Answer Code here"></textarea>
+        <div class="row">
+          <button id="btnApplyAnswer">Apply Answer Code and Connect</button>
+        </div>
+      </div>
+
+      <div class="panel">
+        <h2>Step B (Callee): Create Answer</h2>
+        <div class="row small muted">This side responds to an offer. It will also ask for microphone permission.</div>
+        <textarea id="offerIn" placeholder="Paste Offer Code here"></textarea>
+        <div class="row">
+          <button id="btnAnswer">Create Answer Code</button>
+          <button id="btnCopyAnswer" disabled>Copy Answer Code</button>
+        </div>
+        <textarea id="answerOut" placeholder="Your Answer Code will appear here" readonly></textarea>
+        <div class="row small muted">Send this Answer Code back to the caller using the same channel.</div>
+      </div>
+    </div>
+
+    <div class="audio">
+      <h2>Remote Audio</h2>
+      <audio id="remoteAudio" autoplay playsinline controls></audio>
+      <div class="small muted">If you do not hear remote audio, check your system/browser permissions and volume. Some browsers require a user gesture before playing audio — pressing any button above should be sufficient.</div>
+    </div>
+
+    <div class="small muted" style="margin-top: 16px;">
+      Notes:
+      <ul>
+        <li>There is no server and no persistent signaling — you copy/paste codes manually.</li>
+        <li>Only STUN (no TURN). If strict NATs prevent a direct path, the connection may fail.</li>
+        <li>Microphone access typically requires HTTPS except on localhost. Use a secure origin when testing across devices.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script>
+    const $ = (id) => document.getElementById(id);
+
+    const statusEl = $("status");
+    const btnOffer = $("btnOffer");
+    const btnCopyOffer = $("btnCopyOffer");
+    const offerOut = $("offerOut");
+
+    const answerIn = $("answerIn");
+    const btnApplyAnswer = $("btnApplyAnswer");
+
+    const offerIn = $("offerIn");
+    const btnAnswer = $("btnAnswer");
+    const btnCopyAnswer = $("btnCopyAnswer");
+    const answerOut = $("answerOut");
+
+    const remoteAudio = $("remoteAudio");
+
+    let peerConnection = null;
+    let localStream = null;
+
+    function setStatus(text, type) {
+      statusEl.textContent = text;
+      statusEl.classList.remove("ok", "warn", "err");
+      if (type) statusEl.classList.add(type);
+    }
+
+    function packDescription(desc) {
+      const json = JSON.stringify(desc);
+      const b64 = btoa(json);
+      return b64;
+    }
+
+    function unpackDescription(b64) {
+      try {
+        const json = atob((b64 || "").trim());
+        return JSON.parse(json);
+      } catch (e) {
+        throw new Error("Invalid code: could not decode/parse");
+      }
+    }
+
+    function createPeerConnection() {
+      if (peerConnection) {
+        try { peerConnection.close(); } catch {}
+      }
+
+      peerConnection = new RTCPeerConnection({
+        iceServers: [
+          { urls: [
+            "stun:stun.l.google.com:19302",
+            "stun:stun1.l.google.com:19302",
+            "stun:stun2.l.google.com:19302",
+            "stun:global.stun.twilio.com:3478"
+          ]}
+        ]
+      });
+
+      peerConnection.ontrack = (event) => {
+        const [remoteStream] = event.streams;
+        if (remoteStream) {
+          remoteAudio.srcObject = remoteStream;
+        }
+      };
+
+      peerConnection.oniceconnectionstatechange = () => {
+        setStatus(`ICE: ${peerConnection.iceConnectionState} | PC: ${peerConnection.connectionState}`);
+      };
+
+      peerConnection.onconnectionstatechange = () => {
+        const state = peerConnection.connectionState;
+        if (state === "connected") setStatus("Connected", "ok");
+        else if (state === "failed") setStatus("Connection failed", "err");
+        else setStatus(`State: ${state}`);
+      };
+
+      return peerConnection;
+    }
+
+    async function ensureLocalStream() {
+      if (localStream) return localStream;
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true
+          },
+          video: false
+        });
+        return localStream;
+      } catch (e) {
+        setStatus("Microphone permission denied or unavailable", "err");
+        throw e;
+      }
+    }
+
+    function addLocalTracks(pc, stream) {
+      stream.getTracks().forEach(track => pc.addTrack(track, stream));
+    }
+
+    function waitForIceGatheringComplete(pc) {
+      if (pc.iceGatheringState === "complete") {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => {
+        const checkState = () => {
+          if (pc.iceGatheringState === "complete") {
+            pc.removeEventListener("icegatheringstatechange", checkState);
+            resolve();
+          }
+        };
+        pc.addEventListener("icegatheringstatechange", checkState);
+      });
+    }
+
+    async function createOfferFlow() {
+      setStatus("Creating offer…");
+      const pc = createPeerConnection();
+      const stream = await ensureLocalStream();
+      addLocalTracks(pc, stream);
+
+      const offer = await pc.createOffer({ offerToReceiveAudio: true });
+      await pc.setLocalDescription(offer);
+      await waitForIceGatheringComplete(pc);
+
+      const code = packDescription(pc.localDescription);
+      offerOut.value = code;
+      btnCopyOffer.disabled = false;
+      setStatus("Offer ready. Send it to the callee.", "ok");
+    }
+
+    async function applyAnswerFlow() {
+      if (!peerConnection) {
+        setStatus("No PeerConnection. Create an offer first.", "warn");
+        return;
+      }
+      const b64 = answerIn.value.trim();
+      if (!b64) {
+        setStatus("Answer Code is empty.", "warn");
+        return;
+      }
+      try {
+        const desc = unpackDescription(b64);
+        if (desc.type !== "answer") throw new Error("Code is not an answer");
+        await peerConnection.setRemoteDescription(desc);
+        setStatus("Answer applied. Connecting…", "ok");
+      } catch (e) {
+        console.error(e);
+        setStatus(e.message || "Failed to apply answer", "err");
+      }
+    }
+
+    async function createAnswerFlow() {
+      setStatus("Creating answer…");
+      const pc = createPeerConnection();
+
+      const offerB64 = offerIn.value.trim();
+      if (!offerB64) {
+        setStatus("Offer Code is empty.", "warn");
+        return;
+      }
+
+      let offerDesc;
+      try {
+        offerDesc = unpackDescription(offerB64);
+        if (offerDesc.type !== "offer") throw new Error("Code is not an offer");
+      } catch (e) {
+        setStatus(e.message || "Invalid Offer Code", "err");
+        return;
+      }
+
+      const stream = await ensureLocalStream();
+      addLocalTracks(pc, stream);
+
+      await pc.setRemoteDescription(offerDesc);
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      await waitForIceGatheringComplete(pc);
+
+      const code = packDescription(pc.localDescription);
+      answerOut.value = code;
+      btnCopyAnswer.disabled = false;
+      setStatus("Answer ready. Send it back to the caller.", "ok");
+    }
+
+    btnOffer.addEventListener("click", () => createOfferFlow());
+    btnCopyOffer.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(offerOut.value);
+        setStatus("Offer Code copied to clipboard.", "ok");
+      } catch {
+        setStatus("Clipboard copy failed. Select and copy manually.", "warn");
+      }
+    });
+
+    btnApplyAnswer.addEventListener("click", () => applyAnswerFlow());
+
+    btnAnswer.addEventListener("click", () => createAnswerFlow());
+    btnCopyAnswer.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(answerOut.value);
+        setStatus("Answer Code copied to clipboard.", "ok");
+      } catch {
+        setStatus("Clipboard copy failed. Select and copy manually.", "warn");
+      }
+    });
+
+    // Feature detection
+    if (!("RTCPeerConnection" in window)) {
+      setStatus("WebRTC not supported in this browser.", "err");
+    }
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      setStatus("getUserMedia not supported.", "err");
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Add a WebRTC P2P audio streaming page with manual copy/paste signaling to enable direct device-to-device audio without a backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3555a1b-693e-4b24-a5f6-0c3508ec1e1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3555a1b-693e-4b24-a5f6-0c3508ec1e1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

